### PR TITLE
add host app target to enable tests to run with keychain entitlement

### DIFF
--- a/ELKeychain.xcodeproj/project.pbxproj
+++ b/ELKeychain.xcodeproj/project.pbxproj
@@ -15,6 +15,11 @@
 		171DC9191D24399A0074741D /* AccessControlProtectionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171DC9181D24399A0074741D /* AccessControlProtectionPolicy.swift */; };
 		1723BAFF1D2D805600394EF8 /* AccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1723BAFE1D2D805600394EF8 /* AccessControl.swift */; };
 		1723BB011D2D806200394EF8 /* AccessControlConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1723BB001D2D806200394EF8 /* AccessControlConvertible.swift */; };
+		17B5BC9B1D92E0980034823A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B5BC9A1D92E0980034823A /* AppDelegate.swift */; };
+		17B5BC9D1D92E0980034823A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B5BC9C1D92E0980034823A /* ViewController.swift */; };
+		17B5BCA01D92E0980034823A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 17B5BC9E1D92E0980034823A /* Main.storyboard */; };
+		17B5BCA21D92E0980034823A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 17B5BCA11D92E0980034823A /* Assets.xcassets */; };
+		17B5BCA51D92E0980034823A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 17B5BCA31D92E0980034823A /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -24,6 +29,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 17137CDF1CFDF33100AB46DD;
 			remoteInfo = ELKeychain;
+		};
+		17B5BCAB1D92E0A90034823A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 17137CD71CFDF33100AB46DD /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 17B5BC971D92E0980034823A;
+			remoteInfo = ELKeychainTestHost;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -39,6 +51,14 @@
 		171DC9181D24399A0074741D /* AccessControlProtectionPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessControlProtectionPolicy.swift; sourceTree = "<group>"; };
 		1723BAFE1D2D805600394EF8 /* AccessControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessControl.swift; sourceTree = "<group>"; };
 		1723BB001D2D806200394EF8 /* AccessControlConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessControlConvertible.swift; sourceTree = "<group>"; };
+		17B5BC981D92E0980034823A /* ELKeychainTestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ELKeychainTestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		17B5BC9A1D92E0980034823A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		17B5BC9C1D92E0980034823A /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		17B5BC9F1D92E0980034823A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		17B5BCA11D92E0980034823A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		17B5BCA41D92E0980034823A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		17B5BCA61D92E0980034823A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		17B5BCAD1D92E0BD0034823A /* ELKeychainTestHost.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ELKeychainTestHost.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +77,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		17B5BC951D92E0980034823A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -65,6 +92,7 @@
 			children = (
 				17137CE21CFDF33100AB46DD /* ELKeychain */,
 				17137CEE1CFDF33100AB46DD /* ELKeychainTests */,
+				17B5BC991D92E0980034823A /* ELKeychainTestHost */,
 				17137CE11CFDF33100AB46DD /* Products */,
 			);
 			sourceTree = "<group>";
@@ -74,6 +102,7 @@
 			children = (
 				17137CE01CFDF33100AB46DD /* ELKeychain.framework */,
 				17137CEA1CFDF33100AB46DD /* ELKeychainTests.xctest */,
+				17B5BC981D92E0980034823A /* ELKeychainTestHost.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -99,6 +128,20 @@
 				17137CF11CFDF33100AB46DD /* Info.plist */,
 			);
 			path = ELKeychainTests;
+			sourceTree = "<group>";
+		};
+		17B5BC991D92E0980034823A /* ELKeychainTestHost */ = {
+			isa = PBXGroup;
+			children = (
+				17B5BCAD1D92E0BD0034823A /* ELKeychainTestHost.entitlements */,
+				17B5BC9A1D92E0980034823A /* AppDelegate.swift */,
+				17B5BC9C1D92E0980034823A /* ViewController.swift */,
+				17B5BC9E1D92E0980034823A /* Main.storyboard */,
+				17B5BCA11D92E0980034823A /* Assets.xcassets */,
+				17B5BCA31D92E0980034823A /* LaunchScreen.storyboard */,
+				17B5BCA61D92E0980034823A /* Info.plist */,
+			);
+			path = ELKeychainTestHost;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -145,11 +188,29 @@
 			);
 			dependencies = (
 				17137CED1CFDF33100AB46DD /* PBXTargetDependency */,
+				17B5BCAC1D92E0A90034823A /* PBXTargetDependency */,
 			);
 			name = ELKeychainTests;
 			productName = ELKeychainTests;
 			productReference = 17137CEA1CFDF33100AB46DD /* ELKeychainTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		17B5BC971D92E0980034823A /* ELKeychainTestHost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 17B5BCA71D92E0980034823A /* Build configuration list for PBXNativeTarget "ELKeychainTestHost" */;
+			buildPhases = (
+				17B5BC941D92E0980034823A /* Sources */,
+				17B5BC951D92E0980034823A /* Frameworks */,
+				17B5BC961D92E0980034823A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ELKeychainTestHost;
+			productName = ELKeychainTestHost;
+			productReference = 17B5BC981D92E0980034823A /* ELKeychainTestHost.app */;
+			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
@@ -157,7 +218,7 @@
 		17137CD71CFDF33100AB46DD /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0730;
+				LastSwiftUpdateCheck = 0800;
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Walmart;
 				TargetAttributes = {
@@ -168,6 +229,16 @@
 					17137CE91CFDF33100AB46DD = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 0800;
+						TestTargetID = 17B5BC971D92E0980034823A;
+					};
+					17B5BC971D92E0980034823A = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.Keychain = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};
@@ -177,6 +248,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 17137CD61CFDF33100AB46DD;
 			productRefGroup = 17137CE11CFDF33100AB46DD /* Products */;
@@ -185,6 +257,7 @@
 			targets = (
 				17137CDF1CFDF33100AB46DD /* ELKeychain */,
 				17137CE91CFDF33100AB46DD /* ELKeychainTests */,
+				17B5BC971D92E0980034823A /* ELKeychainTestHost */,
 			);
 		};
 /* End PBXProject section */
@@ -201,6 +274,16 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		17B5BC961D92E0980034823A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17B5BCA51D92E0980034823A /* LaunchScreen.storyboard in Resources */,
+				17B5BCA21D92E0980034823A /* Assets.xcassets in Resources */,
+				17B5BCA01D92E0980034823A /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -227,6 +310,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		17B5BC941D92E0980034823A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17B5BC9D1D92E0980034823A /* ViewController.swift in Sources */,
+				17B5BC9B1D92E0980034823A /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -235,7 +327,31 @@
 			target = 17137CDF1CFDF33100AB46DD /* ELKeychain */;
 			targetProxy = 17137CEC1CFDF33100AB46DD /* PBXContainerItemProxy */;
 		};
+		17B5BCAC1D92E0A90034823A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 17B5BC971D92E0980034823A /* ELKeychainTestHost */;
+			targetProxy = 17B5BCAB1D92E0A90034823A /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		17B5BC9E1D92E0980034823A /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				17B5BC9F1D92E0980034823A /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		17B5BCA31D92E0980034823A /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				17B5BCA41D92E0980034823A /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		17137CF21CFDF33100AB46DD /* Debug */ = {
@@ -376,20 +492,76 @@
 		17137CF81CFDF33100AB46DD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer: Angelo DiPaolo (5224P3TA28)";
 				INFOPLIST_FILE = ELKeychainTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELKeychainTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 2.3;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ELKeychainTestHost.app/ELKeychainTestHost";
 			};
 			name = Debug;
 		};
 		17137CF91CFDF33100AB46DD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer: Angelo DiPaolo (5224P3TA28)";
 				INFOPLIST_FILE = ELKeychainTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELKeychainTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ELKeychainTestHost.app/ELKeychainTestHost";
+			};
+			name = Release;
+		};
+		17B5BCA81D92E0980034823A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_ENTITLEMENTS = ELKeychainTestHost/ELKeychainTestHost.entitlements;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = ELKeychainTestHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmart.ELKeychainTestHost;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 2.3;
+			};
+			name = Debug;
+		};
+		17B5BCA91D92E0980034823A /* QADeployment */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_ENTITLEMENTS = ELKeychainTestHost/ELKeychainTestHost.entitlements;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = ELKeychainTestHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmart.ELKeychainTestHost;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
+			};
+			name = QADeployment;
+		};
+		17B5BCAA1D92E0980034823A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_ENTITLEMENTS = ELKeychainTestHost/ELKeychainTestHost.entitlements;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = ELKeychainTestHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmart.ELKeychainTestHost;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 2.3;
 			};
@@ -470,11 +642,13 @@
 		EAA730361D64FD0D006CAFB0 /* QADeployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer: Angelo DiPaolo (5224P3TA28)";
 				INFOPLIST_FILE = ELKeychainTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELKeychainTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 2.3;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ELKeychainTestHost.app/ELKeychainTestHost";
 			};
 			name = QADeployment;
 		};
@@ -510,6 +684,15 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		17B5BCA71D92E0980034823A /* Build configuration list for PBXNativeTarget "ELKeychainTestHost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				17B5BCA81D92E0980034823A /* Debug */,
+				17B5BCA91D92E0980034823A /* QADeployment */,
+				17B5BCAA1D92E0980034823A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/ELKeychain.xcodeproj/project.pbxproj
+++ b/ELKeychain.xcodeproj/project.pbxproj
@@ -492,7 +492,7 @@
 		17137CF81CFDF33100AB46DD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer: Angelo DiPaolo (5224P3TA28)";
+				CODE_SIGN_IDENTITY = "";
 				INFOPLIST_FILE = ELKeychainTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELKeychainTests;
@@ -505,7 +505,7 @@
 		17137CF91CFDF33100AB46DD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer: Angelo DiPaolo (5224P3TA28)";
+				CODE_SIGN_IDENTITY = "";
 				INFOPLIST_FILE = ELKeychainTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELKeychainTests;
@@ -642,7 +642,7 @@
 		EAA730361D64FD0D006CAFB0 /* QADeployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer: Angelo DiPaolo (5224P3TA28)";
+				CODE_SIGN_IDENTITY = "";
 				INFOPLIST_FILE = ELKeychainTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELKeychainTests;

--- a/ELKeychainTestHost/AppDelegate.swift
+++ b/ELKeychainTestHost/AppDelegate.swift
@@ -1,0 +1,44 @@
+//
+//  AppDelegate.swift
+//  ELKeychainTestHost
+//
+//  Created by Angelo Di Paolo on 9/21/16.
+//  Copyright © 2016 Walmart. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/ELKeychainTestHost/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ELKeychainTestHost/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,48 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ELKeychainTestHost/Base.lproj/LaunchScreen.storyboard
+++ b/ELKeychainTestHost/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/ELKeychainTestHost/Base.lproj/Main.storyboard
+++ b/ELKeychainTestHost/Base.lproj/Main.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/ELKeychainTestHost/ELKeychainTestHost.entitlements
+++ b/ELKeychainTestHost/ELKeychainTestHost.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.walmart.ELKeychainTestHost</string>
+	</array>
+</dict>
+</plist>

--- a/ELKeychainTestHost/Info.plist
+++ b/ELKeychainTestHost/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/ELKeychainTestHost/ViewController.swift
+++ b/ELKeychainTestHost/ViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ViewController.swift
+//  ELKeychainTestHost
+//
+//  Created by Angelo Di Paolo on 9/21/16.
+//  Copyright © 2016 Walmart. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+
+}
+


### PR DESCRIPTION
This change resolves an issue with calling keychain APIs from a unit test
target that is running in the simulator. In iOS 10/Xcode 8, the keychain
API started returning a`-34018/errSecMissingEntitlement` status code
for all operations, indicating that a keychain entitlement was missing.
The issue was resolved be creating a test host app target to run the tests
and configuring the target to enable keychain sharing.
See https://forums.developer.apple.com/thread/60617#170383 for more info.
