### PR TITLE
Add a static framework target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
 osx_image: xcode9.3
 script:
-   - xcodebuild -project ELKeychain.xcodeproj -scheme ELKeychain -sdk iphonesimulator test -destination 'OS=11.1,name=iPhone X' CODE_SIGNING_REQUIRED=NO
+   - xcodebuild -project ELKeychain.xcodeproj -scheme ELKeychain -sdk iphonesimulator clean test -destination 'OS=11.1,name=iPhone X' CODE_SIGNING_REQUIRED=NO
+   - xcodebuild -project ELKeychain.xcodeproj -scheme ELKeychain_static -sdk iphonesimulator clean build -destination 'OS=11.1,name=iPhone X' CODE_SIGNING_REQUIRED=NO

--- a/ELKeychain.xcodeproj/project.pbxproj
+++ b/ELKeychain.xcodeproj/project.pbxproj
@@ -20,6 +20,12 @@
 		17B5BCA01D92E0980034823A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 17B5BC9E1D92E0980034823A /* Main.storyboard */; };
 		17B5BCA21D92E0980034823A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 17B5BCA11D92E0980034823A /* Assets.xcassets */; };
 		17B5BCA51D92E0980034823A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 17B5BCA31D92E0980034823A /* LaunchScreen.storyboard */; };
+		3E8CA3A520E57D9C00CBDA69 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17137CFC1CFDF37400AB46DD /* Keychain.swift */; };
+		3E8CA3A620E57D9C00CBDA69 /* AccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1723BAFE1D2D805600394EF8 /* AccessControl.swift */; };
+		3E8CA3A720E57D9C00CBDA69 /* AccessControlConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1723BB001D2D806200394EF8 /* AccessControlConvertible.swift */; };
+		3E8CA3A820E57D9C00CBDA69 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171DC9161D242AFE0074741D /* KeychainError.swift */; };
+		3E8CA3A920E57D9C00CBDA69 /* AccessControlProtectionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171DC9181D24399A0074741D /* AccessControlProtectionPolicy.swift */; };
+		3E8CA3AC20E57D9C00CBDA69 /* ELKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 17137CE31CFDF33100AB46DD /* ELKeychain.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +65,7 @@
 		17B5BCA41D92E0980034823A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		17B5BCA61D92E0980034823A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		17B5BCAD1D92E0BD0034823A /* ELKeychainTestHost.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ELKeychainTestHost.entitlements; sourceTree = "<group>"; };
+		3E8CA3B220E57D9C00CBDA69 /* ELKeychain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELKeychain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,6 +91,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3E8CA3AA20E57D9C00CBDA69 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -103,6 +117,7 @@
 				17137CE01CFDF33100AB46DD /* ELKeychain.framework */,
 				17137CEA1CFDF33100AB46DD /* ELKeychainTests.xctest */,
 				17B5BC981D92E0980034823A /* ELKeychainTestHost.app */,
+				3E8CA3B220E57D9C00CBDA69 /* ELKeychain.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -152,6 +167,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				17137CE41CFDF33100AB46DD /* ELKeychain.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E8CA3AB20E57D9C00CBDA69 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E8CA3AC20E57D9C00CBDA69 /* ELKeychain.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -212,6 +235,24 @@
 			productReference = 17B5BC981D92E0980034823A /* ELKeychainTestHost.app */;
 			productType = "com.apple.product-type.application";
 		};
+		3E8CA3A320E57D9C00CBDA69 /* ELKeychain_static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3E8CA3AE20E57D9C00CBDA69 /* Build configuration list for PBXNativeTarget "ELKeychain_static" */;
+			buildPhases = (
+				3E8CA3A420E57D9C00CBDA69 /* Sources */,
+				3E8CA3AA20E57D9C00CBDA69 /* Frameworks */,
+				3E8CA3AB20E57D9C00CBDA69 /* Headers */,
+				3E8CA3AD20E57D9C00CBDA69 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ELKeychain_static;
+			productName = ELKeychain;
+			productReference = 3E8CA3B220E57D9C00CBDA69 /* ELKeychain.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -257,6 +298,7 @@
 			projectRoot = "";
 			targets = (
 				17137CDF1CFDF33100AB46DD /* ELKeychain */,
+				3E8CA3A320E57D9C00CBDA69 /* ELKeychain_static */,
 				17137CE91CFDF33100AB46DD /* ELKeychainTests */,
 				17B5BC971D92E0980034823A /* ELKeychainTestHost */,
 			);
@@ -285,6 +327,13 @@
 				17B5BCA51D92E0980034823A /* LaunchScreen.storyboard in Resources */,
 				17B5BCA21D92E0980034823A /* Assets.xcassets in Resources */,
 				17B5BCA01D92E0980034823A /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E8CA3AD20E57D9C00CBDA69 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -317,6 +366,18 @@
 			files = (
 				17B5BC9D1D92E0980034823A /* ViewController.swift in Sources */,
 				17B5BC9B1D92E0980034823A /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E8CA3A420E57D9C00CBDA69 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E8CA3A520E57D9C00CBDA69 /* Keychain.swift in Sources */,
+				3E8CA3A620E57D9C00CBDA69 /* AccessControl.swift in Sources */,
+				3E8CA3A720E57D9C00CBDA69 /* AccessControlConvertible.swift in Sources */,
+				3E8CA3A820E57D9C00CBDA69 /* KeychainError.swift in Sources */,
+				3E8CA3A920E57D9C00CBDA69 /* AccessControlProtectionPolicy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -593,6 +654,63 @@
 			};
 			name = Release;
 		};
+		3E8CA3AF20E57D9C00CBDA69 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELKeychain/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELKeychain;
+				PRODUCT_NAME = ELKeychain;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		3E8CA3B020E57D9C00CBDA69 /* QADeployment */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELKeychain/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELKeychain;
+				PRODUCT_NAME = ELKeychain;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = QADeployment;
+		};
+		3E8CA3B120E57D9C00CBDA69 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELKeychain/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELKeychain;
+				PRODUCT_NAME = ELKeychain;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
 		EAA730341D64FD0D006CAFB0 /* QADeployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -728,6 +846,16 @@
 				17B5BCA81D92E0980034823A /* Debug */,
 				17B5BCA91D92E0980034823A /* QADeployment */,
 				17B5BCAA1D92E0980034823A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3E8CA3AE20E57D9C00CBDA69 /* Build configuration list for PBXNativeTarget "ELKeychain_static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3E8CA3AF20E57D9C00CBDA69 /* Debug */,
+				3E8CA3B020E57D9C00CBDA69 /* QADeployment */,
+				3E8CA3B120E57D9C00CBDA69 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ github "Electrode-iOS/ELKeychain"
 
 Install manually by adding `ELKeychain.xcodeproj` to your project and configuring your target to link `ELKeychain.framework`.
 
+There are two target that builds `ELKeychain.framework`.
+1. `ELKeychain`: Creates dynamicly linked `ELKeychain.framework.`
+2. `ELKeychain_static`: Creates staticly linked `ELKeychain.framework`.
+
+Both targets build the same product (`ELKeychain.framework`), thus linking the same app against both `ELKeychain` and `ELKeychain_static` should be avoided.
+
 ## Usage
 
 ### Storing a Generic Password Item

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ github "Electrode-iOS/ELKeychain"
 Install manually by adding `ELKeychain.xcodeproj` to your project and configuring your target to link `ELKeychain.framework`.
 
 There are two target that builds `ELKeychain.framework`.
-1. `ELKeychain`: Creates dynamicly linked `ELKeychain.framework.`
-2. `ELKeychain_static`: Creates staticly linked `ELKeychain.framework`.
+1. `ELKeychain`: Creates dynamically linked `ELKeychain.framework.`
+2. `ELKeychain_static`: Creates statically linked `ELKeychain.framework`.
 
 Both targets build the same product (`ELKeychain.framework`), thus linking the same app against both `ELKeychain` and `ELKeychain_static` should be avoided.
 


### PR DESCRIPTION
This change adds a new target named `ELKeychain_static`. This target builds a static version of `ELKeychain.framework.` 
- It shares the same source files as dynamic ELKeychain framework and builds a product with the same name. 
- Framework's module name is also the same as that of dynamic framework.
- It uses the same Info.plist file as dynamic framework target.
- Travis script is updated to build both targets and clean before building.

Going forward, `ELKeychain_static` framework needs to be managed as well as `ELKeychain` target. Sources added or removed, build setting changes, build phase changes should be reflected on `ELKeychain_static` target.

